### PR TITLE
Create math student themed portfolio site

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -4,42 +4,55 @@
  */
 
 :root {
-  --primary: #1d3557;
-  --secondary: #457b9d;
-  --accent: #e63946;
-  --background: #f1faee;
-  --text: #1f1f1f;
+  --primary: #102a43;
+  --secondary: #335c81;
+  --accent: #ff6f61;
+  --highlight: #5eead4;
+  --background: #f4f7fb;
+  --text: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
-  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Helvetica Neue', 'Segoe UI', sans-serif;
   background: var(--background);
   color: var(--text);
   margin: 0;
   padding: 0;
+  line-height: 1.6;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--primary);
+  margin-top: 0;
 }
 
 h1 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-  color: var(--primary);
+  font-size: 2.6rem;
+  letter-spacing: -0.02em;
 }
 
 main {
   max-width: 1100px;
   margin: 0 auto;
+  padding: 0 1.5rem 4rem;
 }
 
 .navbar {
-  background: white;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(16, 42, 67, 0.08);
   position: sticky;
   top: 0;
   z-index: 100;
-}
-
-.navbar.navbar-shadow {
-  box-shadow: 0 4px 16px rgba(29, 53, 87, 0.15);
 }
 
 .navbar .container {
@@ -57,13 +70,13 @@ main {
 .brand {
   color: var(--primary);
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.2rem;
   text-decoration: none;
 }
 
 .nav-links {
   display: flex;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .nav-link {
@@ -72,31 +85,12 @@ main {
   font-weight: 500;
   position: relative;
   padding-bottom: 0.25rem;
+  transition: color 0.2s ease;
 }
 
-.button {
-  display: inline-block;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  text-decoration: none;
-  font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.button.primary {
-  background: var(--accent);
-  color: white;
-  box-shadow: 0 12px 24px rgba(230, 57, 70, 0.3);
-}
-
-.button.secondary {
-  background: white;
-  color: var(--primary);
-  border: 2px solid var(--primary);
-}
-
-.button:hover {
-  transform: translateY(-2px);
+.nav-link.active,
+.nav-link:hover {
+  color: var(--accent);
 }
 
 .nav-link.active::after,
@@ -110,103 +104,117 @@ main {
   background: var(--accent);
 }
 
-.hero {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
+.button {
+  display: inline-flex;
   align-items: center;
-  padding: 4rem 2rem;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.hero img {
-  width: 100%;
-  border-radius: 50%;
-  box-shadow: 0 20px 40px rgba(29, 53, 87, 0.25);
+.button.primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 14px 28px rgba(255, 111, 97, 0.35);
+}
+
+.button.secondary {
+  background: white;
+  color: var(--primary);
+  border: 2px solid rgba(16, 42, 67, 0.15);
+}
+
+.button.ghost {
+  background: transparent;
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.button:hover {
+  transform: translateY(-2px);
 }
 
 .section {
-  padding: 3rem 2rem;
+  padding: 3.5rem 0;
 }
 
 .section h2 {
-  color: var(--primary);
-  border-bottom: 2px solid var(--secondary);
-  padding-bottom: 0.5rem;
-  margin-bottom: 1.5rem;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.section h2::after {
+  content: '';
+  flex: 1 1 auto;
+  height: 1px;
+  background: linear-gradient(90deg, var(--secondary), transparent);
 }
 
 .section p {
-  line-height: 1.8;
+  margin: 0 0 1rem;
 }
 
-.section ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.section ul li {
-  margin-bottom: 0.75rem;
-  font-weight: 500;
-}
-
-.section ul li a {
-  color: var(--secondary);
-  text-decoration: none;
-}
-
-.section ul li a:hover {
-  text-decoration: underline;
+.section-subtitle {
+  color: rgba(16, 42, 67, 0.7);
+  margin-bottom: 2rem;
+  font-size: 1.05rem;
 }
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
 }
 
 .card {
   background: white;
-  padding: 1.5rem;
-  border-radius: 12px;
-  box-shadow: 0 12px 24px rgba(29, 53, 87, 0.12);
-  border-top: 4px solid var(--secondary);
+  padding: 1.75rem;
+  border-radius: 16px;
+  box-shadow: 0 18px 30px rgba(16, 42, 67, 0.08);
+  border: 1px solid rgba(16, 42, 67, 0.08);
 }
 
 .card h3 {
-  margin-top: 0;
-  color: var(--primary);
+  margin-bottom: 0.75rem;
 }
 
 .card p {
+  margin: 0 0 0.75rem;
   line-height: 1.7;
 }
 
 .timeline {
-  border-left: 3px solid var(--secondary);
-  margin-left: 0.5rem;
+  border-left: 3px solid rgba(51, 92, 129, 0.25);
   padding-left: 1.5rem;
   display: grid;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .timeline-item {
   position: relative;
+  padding-left: 0.5rem;
 }
 
 .timeline-item::before {
   content: '';
   position: absolute;
   left: -1.73rem;
-  top: 0.2rem;
+  top: 0.3rem;
   width: 12px;
   height: 12px;
-  background: var(--accent);
+  background: var(--highlight);
   border-radius: 50%;
+  box-shadow: 0 0 0 6px rgba(94, 234, 212, 0.2);
 }
 
 .timeline-item h3 {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.35rem;
   color: var(--secondary);
 }
 
@@ -214,14 +222,171 @@ main {
   background: var(--primary);
   color: white;
   text-align: center;
-  padding: 2rem;
+  padding: 2.5rem 1.5rem;
   margin-top: 4rem;
 }
 
 .footer a {
-  color: var(--background);
+  color: var(--highlight);
   text-decoration: none;
-  margin: 0 0.5rem;
+  margin: 0 0.75rem;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+.student-hero {
+  position: relative;
+  background: linear-gradient(135deg, rgba(16, 42, 67, 0.95), rgba(51, 92, 129, 0.85));
+  color: white;
+  border-radius: 28px;
+  padding: 4rem;
+  margin-top: 2.5rem;
+  overflow: hidden;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.student-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(94, 234, 212, 0.35), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(255, 111, 97, 0.25), transparent 60%);
+  mix-blend-mode: screen;
+}
+
+.hero-content,
+.hero-card {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.hero-card {
+  background: rgba(10, 21, 40, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 24px;
+  padding: 2rem;
+  backdrop-filter: blur(10px);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero-card h2 {
+  color: white;
+  margin-bottom: 1rem;
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+  font-size: 0.9rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.65rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(94, 234, 212, 0.2);
+  color: var(--secondary);
+}
+
+.resource-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.resource-card {
+  background: white;
+  border-radius: 14px;
+  padding: 1.5rem;
+  border: 1px solid rgba(16, 42, 67, 0.1);
+  box-shadow: 0 16px 30px rgba(16, 42, 67, 0.08);
+}
+
+.resource-card h3 {
+  margin-bottom: 0.5rem;
+}
+
+.highlight-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.highlight-list li {
+  background: white;
+  border-radius: 12px;
+  padding: 1.2rem 1.5rem;
+  border: 1px solid rgba(16, 42, 67, 0.08);
+  box-shadow: 0 12px 24px rgba(16, 42, 67, 0.07);
+}
+
+.highlight-list strong {
+  display: block;
+  color: var(--secondary);
+  margin-bottom: 0.35rem;
+}
+
+.highlight-list p {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.hero-card .highlight-list li {
+  background: rgba(15, 34, 60, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero-card .highlight-list strong {
+  color: white;
+}
+
+.hero-card .highlight-list p {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 @media (max-width: 720px) {
@@ -230,11 +395,15 @@ main {
     gap: 1rem;
   }
 
-  .hero {
-    padding: 2rem 1rem;
+  main {
+    padding: 0 1rem 3rem;
+  }
+
+  .student-hero {
+    padding: 2.5rem;
   }
 
   .section {
-    padding: 2rem 1rem;
+    padding: 2.5rem 0;
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= page_title(content_for?(:title) ? yield(:title) : nil) %></title>
-    <meta name="description" content="数学者としての研究・教育・講演・出版活動を紹介するポートフォリオサイト">
+    <meta name="description" content="大学で数学を学ぶ学生ユウのポートフォリオ。研究プロジェクト、学習ノート、イベント登壇、アウトプットをまとめた GitHub Pages 向けウェブサイト。">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -33,9 +33,9 @@
     <footer class="footer">
       <p>&copy; <%= Time.current.year %> <%= t('math_website.title') %></p>
       <p>
-        <%= link_to 'ORCID', 'https://orcid.org', target: '_blank', rel: 'noopener' %>
-        <%= link_to 'MathSciNet', 'https://mathscinet.ams.org', target: '_blank', rel: 'noopener' %>
-        <%= link_to 'arXiv', 'https://arxiv.org', target: '_blank', rel: 'noopener' %>
+        <%= link_to 'GitHub', 'https://github.com', target: '_blank', rel: 'noopener' %>
+        <%= link_to 'Zenn', 'https://zenn.dev', target: '_blank', rel: 'noopener' %>
+        <%= link_to 'Speaker Deck', 'https://speakerdeck.com', target: '_blank', rel: 'noopener' %>
       </p>
     </footer>
   </body>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,31 +1,42 @@
-<% content_for :title, '連絡先' %>
+<% content_for :title, 'コンタクト' %>
 <section class="section">
-  <h1>連絡先</h1>
-  <p>共同研究・講演依頼・学生の指導に関するご相談は、以下の連絡先よりお気軽にお問い合わせください。</p>
+  <h1>コンタクト</h1>
+  <p class="section-subtitle">
+    コラボレーションの相談、勉強会のお誘い、GitHub Pages を使った数学サイトづくりの質問など、気軽にご連絡ください。
+  </p>
 </section>
 
 <section class="section">
   <div class="card-grid">
     <article class="card">
       <h2>所属</h2>
-      <p>東京数学大学 理学研究科 数学専攻<br>准教授</p>
+      <p>東京数学大学 理学部 数学科<br>学部 3 年</p>
     </article>
     <article class="card">
       <h2>メール</h2>
-      <p><%= mail_to 'yamada@example.jp' %></p>
+      <p><%= mail_to 'yu.math@example.jp' %></p>
     </article>
     <article class="card">
-      <h2>研究室</h2>
-      <p>東京都千代田区学術町 1-2-3<br>理学部棟 5F 512 号室</p>
+      <h2>活動拠点</h2>
+      <p>東京都千代田区 学術キャンパス内<br>学生ラウンジ・メイカースペース</p>
     </article>
   </div>
 </section>
 
 <section class="section">
   <h2>オンラインアカウント</h2>
-  <ul>
-    <li><%= link_to 'GitHub', 'https://github.com', target: '_blank', rel: 'noopener' %></li>
-    <li><%= link_to 'Google Scholar', 'https://scholar.google.com', target: '_blank', rel: 'noopener' %></li>
-    <li><%= link_to 'ResearchGate', 'https://www.researchgate.net', target: '_blank', rel: 'noopener' %></li>
+  <ul class="highlight-list">
+    <li>
+      <strong>GitHub</strong>
+      <p><%= link_to 'github.com/yu-math', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </li>
+    <li>
+      <strong>Qiita</strong>
+      <p><%= link_to 'qiita.com/yu_math', 'https://qiita.com', target: '_blank', rel: 'noopener' %></p>
+    </li>
+    <li>
+      <strong>YouTube</strong>
+      <p><%= link_to 'Math Log Channel', 'https://youtube.com', target: '_blank', rel: 'noopener' %></p>
+    </li>
   </ul>
 </section>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,51 +1,103 @@
 <% content_for :title, 'ホーム' %>
-<section class="hero section">
-  <div>
-    <h1>山田 太郎</h1>
-    <p>数論と表現論を専門とする数学者。保型形式とモチーフの相互作用を通じて、数の世界に潜む対称性を探究しています。</p>
+<section class="hero section student-hero">
+  <div class="hero-content">
+    <span class="hero-eyebrow">Number Theory ・ Data Science ・ Visualization</span>
+    <h1>ユウ / Math Student</h1>
     <p>
-      <%= link_to '研究活動を見る', research_path, class: 'button primary' %>
-      <%= link_to '最新の講演情報', talks_path, class: 'button secondary' %>
+      東京の大学で数学を学ぶ 3 年生です。数論の美しさに魅了されながら、データサイエンスや可視化の技術を組み合わせて、
+      抽象的なアイデアを誰もが手に取れる形で表現することに挑戦しています。GitHub Pages で公開するために最適化された、
+      私の活動と学びをまとめたポートフォリオです。
     </p>
+    <div class="hero-actions">
+      <%= link_to 'GitHub を見る', 'https://github.com', class: 'button primary', target: '_blank', rel: 'noopener' %>
+      <%= link_to '学習ノート', teaching_path, class: 'button secondary' %>
+      <%= link_to '最新アウトプット', publications_path, class: 'button ghost' %>
+    </div>
+    <ul class="pill-list">
+      <li class="pill">💡 解析数論とゼータ関数</li>
+      <li class="pill">🧮 数学オリンピックでの経験</li>
+      <li class="pill">💻 Python ・ Julia ・ Ruby</li>
+    </ul>
     <p data-controller="hello"></p>
   </div>
-  <div>
-    <%= image_tag 'profile.jpg', alt: '数学者のポートレート' %>
+  <div class="hero-card">
+    <h2>今取り組んでいること</h2>
+    <ul class="highlight-list">
+      <li>
+        <strong>ゼータ関数の可視化研究</strong>
+        <p>複素平面上の振る舞いを WebGL と GLSL でインタラクティブに表示する個人プロジェクトを開発中。</p>
+      </li>
+      <li>
+        <strong>数理モデリングサークル</strong>
+        <p>週 1 回の勉強会で実社会の課題を数理最適化問題として定式化し、Python で検証。</p>
+      </li>
+      <li>
+        <strong>GitHub Pages チュートリアル</strong>
+        <p>数学を学ぶ高校生向けに、微分方程式入門記事を公開予定。LaTeX で書いたノートを Rails で整形。</p>
+      </li>
+    </ul>
   </div>
 </section>
 
 <section class="section">
-  <h2>研究トピック</h2>
+  <h2>学習テーマ</h2>
+  <p class="section-subtitle">授業・自主研究・コンテストを通じて磨いている数学の領域です。</p>
   <div class="card-grid">
     <article class="card">
-      <h3>Langlands プログラム</h3>
-      <p>保型表現の局所・大域対応と L-関数の解析的性質に関する研究。</p>
+      <h3>保型形式と L-関数</h3>
+      <p>モジュラー形式のフーリエ係数と L-関数の零点の分布を、計算実験と文献輪講で調査しています。</p>
+      <span class="badge">使用ツール: SageMath / Pari</span>
     </article>
     <article class="card">
-      <h3>p-進数解析</h3>
-      <p>ガロア表現の変形理論と幾何学的 p-進 Hodge 理論の応用。</p>
+      <h3>離散最適化</h3>
+      <p>競技プログラミングと数理計画法の双方から、整数計画問題の解法やカット生成を実装。</p>
+      <span class="badge">研究会: 数理モデリング部</span>
     </article>
     <article class="card">
-      <h3>算術幾何</h3>
-      <p>モジュライ空間のコンパクト化と特異点解消を通じた算術的対称性の理解。</p>
+      <h3>可視化とフロントエンド</h3>
+      <p>Three.js と D3.js を用いた実験的なグラフやフラクタル表示の UI/UX を設計しています。</p>
+      <span class="badge">実装言語: TypeScript</span>
     </article>
   </div>
 </section>
 
 <section class="section">
-  <h2>最近の成果</h2>
+  <h2>制作したプロジェクト</h2>
+  <p class="section-subtitle">GitHub で公開している自主研究やハッカソン作品のハイライト。</p>
+  <div class="card-grid">
+    <article class="card">
+      <h3>Zeta Explorer</h3>
+      <p>リーマンゼータ関数の複素零点をインタラクティブに表示する Web アプリ。平面上の位相を色相で表現。</p>
+      <p><%= link_to 'リポジトリを見る', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </article>
+    <article class="card">
+      <h3>Math Notes Generator</h3>
+      <p>Markdown の証明メモを Rails でビルドして GitHub Pages にデプロイできる CLI ツール。</p>
+      <p><%= link_to 'ドキュメント', publications_path %></p>
+    </article>
+    <article class="card">
+      <h3>Contest Analytics</h3>
+      <p>過去の数学コンテストの問題傾向をデータベース化し、分野別の学習プランをレコメンド。</p>
+      <p><%= link_to '学習ノートで読む', teaching_path %></p>
+    </article>
+  </div>
+</section>
+
+<section class="section">
+  <h2>最近のトピック</h2>
+  <p class="section-subtitle">日々の学びやコンテスト、イベント参加の記録。</p>
   <div class="timeline">
     <div class="timeline-item">
-      <h3>2024 年 10 月</h3>
-      <p>保型 L-関数の特殊値に関する共同研究が <em>Journal of Number Theory</em> に採択。</p>
+      <h3>2025 年 2 月</h3>
+      <p>大学合同ゼミでリーマン予想の背景と関数方程式に関する発表を担当。</p>
     </div>
     <div class="timeline-item">
-      <h3>2024 年 6 月</h3>
-      <p>国際会議「Automorphic Forms and Beyond」で招待講演を実施。</p>
+      <h3>2024 年 11 月</h3>
+      <p>国際学生数学コンテスト (IMC) にチームで参加し、解析分野で銀賞獲得。</p>
     </div>
     <div class="timeline-item">
-      <h3>2023 年 12 月</h3>
-      <p>JSPS 研究費（基盤 B）「保型形式の算術的側面の研究」採択。</p>
+      <h3>2024 年 7 月</h3>
+      <p>GitHub Pages で数学ブログ「Proof Sketch」を公開。週 1 本のペースで連載中。</p>
     </div>
   </div>
 </section>

--- a/app/views/pages/publications.html.erb
+++ b/app/views/pages/publications.html.erb
@@ -1,26 +1,43 @@
-<% content_for :title, '出版' %>
+<% content_for :title, 'アウトプット' %>
 <section class="section">
-  <h1>論文・出版物</h1>
-  <p>査読付き論文、プレプリント、著書などの主要な成果を掲載しています。詳細な bibliographic 情報は MathSciNet や arXiv からも確認できます。</p>
+  <h1>アウトプット</h1>
+  <p class="section-subtitle">
+    GitHub Pages で公開している記事、スライド、動画などのアウトプットをまとめています。数学の楽しさと学習のプロセスを可視化することを意識しています。
+  </p>
+  <div class="card-grid">
+    <article class="card">
+      <h3>Proof Sketch シリーズ</h3>
+      <p>ゼータ関数の歴史、保型形式との関わり、最新研究のトピックを解説するブログ連載。</p>
+      <p><%= link_to 'ブログで読む', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </article>
+    <article class="card">
+      <h3>ゼータ関数可視化スライド</h3>
+      <p>Student Number Theory Day で発表したスライド。インタラクティブデモとコード解説付き。</p>
+      <p><%= link_to 'Speaker Deck', 'https://speakerdeck.com', target: '_blank', rel: 'noopener' %></p>
+    </article>
+    <article class="card">
+      <h3>Math Modeling Podcast</h3>
+      <p>サークルメンバーと毎月収録している勉強会のポッドキャスト。モデル化の裏側を語っています。</p>
+      <p><%= link_to '最新エピソード', '#', class: 'button secondary' %></p>
+    </article>
+  </div>
 </section>
 
 <section class="section">
-  <h2>代表的な論文</h2>
-  <div class="card-grid">
-    <article class="card">
-      <h3>Arithmetic aspects of eigenvarieties</h3>
-      <p><em>Annals of Mathematics</em>, 2024.</p>
-      <p>固有値多様体のローカル構造とガロア表現の変形空間を結びつける新しい剛性定理を提示。</p>
-    </article>
-    <article class="card">
-      <h3>Special values of automorphic L-functions</h3>
-      <p><em>Journal of Number Theory</em>, 2023.</p>
-      <p>ランク 2 の保型表現に対する L-関数特殊値の代数的性質を解明し、Beilinson 予想の一部を検証。</p>
-    </article>
-    <article class="card">
-      <h3>Geometric approaches to p-adic Hodge theory</h3>
-      <p><em>Inventiones Mathematicae</em>, 2022.</p>
-      <p>p-進 Hodge 理論における新たなフィルトレーション構造を提案し、算術幾何への応用を示した。</p>
-    </article>
-  </div>
+  <h2>書いたもの</h2>
+  <p class="section-subtitle">論考やレポート、エッセイの抜粋です。PDF は GitHub Pages からダウンロードできます。</p>
+  <ul class="highlight-list">
+    <li>
+      <strong>ハーディの Z 関数に関するノート</strong>
+      <p>複素平面上の零点分布を追跡するための解析手法をまとめました。</p>
+    </li>
+    <li>
+      <strong>整数計画におけるカット生成の実装</strong>
+      <p>外部インターンでの実装経験を振り返り、改善したヒューリスティクスを紹介。</p>
+    </li>
+    <li>
+      <strong>数学コミュニティ運営の手引き</strong>
+      <p>オンラインでの輪講やイベント企画のノウハウをまとめたガイド。</p>
+    </li>
+  </ul>
 </section>

--- a/app/views/pages/research.html.erb
+++ b/app/views/pages/research.html.erb
@@ -1,23 +1,61 @@
-<% content_for :title, '研究' %>
+<% content_for :title, 'プロジェクト' %>
 <section class="section">
-  <h1>研究概要</h1>
-  <p>保型形式・L-関数・算術幾何を横断するテーマに取り組み、数の幾何学的構造と表現論の架け橋を構築しています。最新の研究では、p-進的手法を用いたモジュラー形式の変形空間の解析に重点を置いています。</p>
+  <h1>プロジェクトと探究テーマ</h1>
+  <p class="section-subtitle">
+    大学の研究室や自主ゼミ、オンラインコミュニティで進めている数学プロジェクトの記録です。GitHub Pages を活用して、
+    コードとレポートを誰でも再現できる形で公開しています。
+  </p>
+  <div class="card-grid">
+    <article class="card">
+      <h3>1. L-関数の計算実験</h3>
+      <p>モジュラー形式から生成される L-関数の数値計算を Julia で実装。ゼータ関数の零点探索アルゴリズムを比較検証。</p>
+      <p><span class="badge">成果</span> 学内研究発表会 2024 優秀賞</p>
+    </article>
+    <article class="card">
+      <h3>2. シンプレクティック幾何の可視化</h3>
+      <p>シンプレクティック多様体の局所構造を WebGL でインタラクティブ表示。シンプレクティック写像の変形をアニメーション化。</p>
+      <p><span class="badge">技術</span> Three.js / GLSL / Rails</p>
+    </article>
+    <article class="card">
+      <h3>3. 数学コンテスト分析</h3>
+      <p>国内外のコンテスト問題を分野別にラベル付けし、学習計画を最適化する推薦システムを構築。</p>
+      <p><span class="badge">共同</span> 数理モデリングサークル</p>
+    </article>
+  </div>
 </section>
 
 <section class="section">
-  <h2>主な研究プロジェクト</h2>
-  <div class="card-grid">
-    <article class="card">
-      <h3>1. 局所 Langlands 対応の明示化</h3>
-      <p>特異指標を持つガロア表現と保型表現のパラメータ化に関する新たな明示的記述を構築。</p>
-    </article>
-    <article class="card">
-      <h3>2. L-関数の特殊値とモチーフ</h3>
-      <p>Beilinson 予想に関連する特殊値の代数的性質を解明するためのモチーフ的アプローチ。</p>
-    </article>
-    <article class="card">
-      <h3>3. 幾何学的 p-進 Hodge 理論</h3>
-      <p>完備交代多様体上の p-進係数層のコホモロジーを解析するための新しいフィルトレーション理論。</p>
-    </article>
+  <h2>研究ログ</h2>
+  <p class="section-subtitle">定期的な振り返りと今後の展望をまとめています。</p>
+  <div class="timeline">
+    <div class="timeline-item">
+      <h3>2025 年 春学期</h3>
+      <p>ゼータ関数の特異点解析をテーマに卒業研究をスタート。ラマヌジャン和の挙動を調査中。</p>
+    </div>
+    <div class="timeline-item">
+      <h3>2024 年 秋学期</h3>
+      <p>複素解析ゼミで Laguerre の補題に関する輪講を担当し、証明と応用を講義ノートに整理。</p>
+    </div>
+    <div class="timeline-item">
+      <h3>2024 年 夏</h3>
+      <p>外部研究インターンで数理最適化の問題設定と線形計画の高速解法を実装。業務データに適用。</p>
+    </div>
   </div>
+</section>
+
+<section class="section">
+  <h2>公開リソース</h2>
+  <p class="section-subtitle">GitHub Pages の静的サイトとして、そのままホストできる資料やツールです。</p>
+  <ul class="resource-list">
+    <li class="resource-card">
+      <h3>ゼータ関数実験ノート</h3>
+      <p>LaTeX で作成したノートを Rails で HTML 化し、GitHub Actions で自動ビルドするワークフローを公開。</p>
+      <p><%= link_to 'ワークフローを見る', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </li>
+    <li class="resource-card">
+      <h3>数理モデリング課題集</h3>
+      <p>実社会の課題をモデル化するステップをまとめた PDF と、対応する Jupyter Notebook を配布しています。</p>
+      <p><%= link_to 'GitHub Pages で読む', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </li>
+  </ul>
 </section>

--- a/app/views/pages/talks.html.erb
+++ b/app/views/pages/talks.html.erb
@@ -1,39 +1,38 @@
-<% content_for :title, '講演' %>
+<% content_for :title, 'イベント' %>
 <section class="section">
-  <h1>講演・セミナー</h1>
-  <p>国内外の研究集会での招待講演や、大学・研究所でのセミナー登壇情報です。講演資料は可能な限り公開しています。</p>
-</section>
-
-<section class="section">
-  <h2>今後の予定</h2>
+  <h1>イベント・登壇</h1>
+  <p class="section-subtitle">
+    学会や学生コミュニティでの発表、ワークショップ運営の記録です。資料は GitHub Pages に掲載し、再利用できるように整備しています。
+  </p>
   <div class="card-grid">
     <article class="card">
-      <h3>2025 年 3 月</h3>
-      <p>Kyoto Workshop on Automorphic Forms にて「Eigenvarieties の解析」について講演予定。</p>
-      <p><%= link_to '概要を読む', '#', class: 'button secondary' %></p>
+      <h3>2025 年 3 月 — Student Number Theory Day</h3>
+      <p>共形写像とゼータ関数の関係をテーマに招待講演。ゼータ関数の可視化デモをライブで実施しました。</p>
+      <p><%= link_to 'スライド', 'https://speakerdeck.com', target: '_blank', rel: 'noopener' %></p>
     </article>
     <article class="card">
-      <h3>2025 年 5 月</h3>
-      <p>東京大学数物セミナーにて「保型 L-関数の特殊値と局所対応」講演予定。</p>
-      <p><%= link_to '概要を読む', '#', class: 'button secondary' %></p>
+      <h3>2024 年 12 月 — GitHub Pages Workshop</h3>
+      <p>数学ノートを Rails と GitHub Actions で自動公開する方法を解説するハンズオンセッションを開催。</p>
+      <p><%= link_to '資料とソース', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
     </article>
   </div>
 </section>
 
 <section class="section">
-  <h2>過去の講演</h2>
+  <h2>参加したプログラム</h2>
+  <p class="section-subtitle">挑戦したイベントを振り返り、得られた学びをまとめています。</p>
   <div class="timeline">
     <div class="timeline-item">
-      <h3>2024 年 10 月</h3>
-      <p>東京工業大学 表現論セミナー「モジュラー性を持つガロア表現の変形」。</p>
+      <h3>2025 年 1 月</h3>
+      <p>大学横断の数学コミュニティでハッカソン。ゼータ関数の可視化アイデアが最優秀賞を受賞。</p>
     </div>
     <div class="timeline-item">
-      <h3>2024 年 2 月</h3>
-      <p>数論若手の会「p-進変形空間と固有値多様体の解析」。</p>
+      <h3>2024 年 9 月</h3>
+      <p>研究インターン成果発表会で線形計画を用いた需要予測モデルを発表。</p>
     </div>
     <div class="timeline-item">
-      <h3>2023 年 9 月</h3>
-      <p>ICM Satellite Conference on Arithmetic Geometry「Shimura 多様体の境界挙動」。</p>
+      <h3>2024 年 5 月</h3>
+      <p>IMC 直前合宿のチューターを担当し、解析セクションの問題解法講座を実施。</p>
     </div>
   </div>
 </section>

--- a/app/views/pages/teaching.html.erb
+++ b/app/views/pages/teaching.html.erb
@@ -1,23 +1,44 @@
-<% content_for :title, '教育' %>
+<% content_for :title, '学習ノート' %>
 <section class="section">
-  <h1>教育活動</h1>
-  <p>学部・大学院向けに数論・表現論・幾何学の講義を担当し、学生と共に未解決問題へ挑戦しています。教育においては、直感的理解と rigorous な証明の両立を重視しています。</p>
+  <h1>学習ノート</h1>
+  <p class="section-subtitle">
+    授業や自主ゼミ、オンライン講義で学んだ内容を GitHub Pages 用に整えたノートです。証明のアイデアや図を交えて、
+    同じテーマに挑戦する仲間と共有できるようにしています。
+  </p>
+  <div class="card-grid">
+    <article class="card">
+      <h3>代数的整数論入門</h3>
+      <p>Dedekind 整数環のイデアル分解、ガロア理論とのつながり、クラス数公式を扱った 10 章構成のノート。</p>
+      <p><%= link_to 'ノートを見る', 'https://github.com', target: '_blank', rel: 'noopener' %></p>
+    </article>
+    <article class="card">
+      <h3>フーリエ解析とゼータ関数</h3>
+      <p>Poisson 和公式から始まり、ディリクレ級数の解析接続、関数方程式までを図とともに整理。</p>
+      <p><%= link_to 'PDF をダウンロード', '#', class: 'button secondary' %></p>
+    </article>
+    <article class="card">
+      <h3>離散最適化ワークブック</h3>
+      <p>整数計画の基本と実装例を Jupyter Notebook でまとめ、GitHub Pages に埋め込み。</p>
+      <p><%= link_to 'ワークブックを見る', '#', class: 'button secondary' %></p>
+    </article>
+  </div>
 </section>
 
 <section class="section">
-  <h2>担当科目</h2>
+  <h2>勉強会での役割</h2>
+  <p class="section-subtitle">チーム学習で意識していることや担当している活動です。</p>
   <div class="card-grid">
     <article class="card">
-      <h3>代数的数論（大学院）</h3>
-      <p>クラス体論と Iwasawa 理論の基礎から最新トピックまでを扱う集中講義。</p>
+      <h3>輪講のモデレーター</h3>
+      <p>複素解析の輪講で議論を整理し、週 1 回のまとめ資料を作成。欠席者向けに録画リンクも共有。</p>
     </article>
     <article class="card">
-      <h3>表現論入門（学部）</h3>
-      <p>群の表現、指標理論、有限次元表現の分類を演習と共に学ぶ。</p>
+      <h3>問題作成</h3>
+      <p>数学コンテスト練習用にオリジナル問題を作り、難易度タグを付与。GitHub Pages で公開しています。</p>
     </article>
     <article class="card">
-      <h3>数学特別演習</h3>
-      <p>研究志向の学生と共に原著論文を輪講し、研究計画立案を支援。</p>
+      <h3>メンタリング</h3>
+      <p>後輩向けに「数学で伝える力」をテーマにしたワークショップを企画し、プレゼン資料を共有。</p>
     </article>
   </div>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,11 +1,11 @@
 en:
   hello: "Hello world"
   math_website:
-    title: "Mathematician Portfolio"
+    title: "数学ノート by ユウ"
     navigation:
-      home: "Home"
-      research: "Research"
-      teaching: "Teaching"
-      talks: "Talks"
-      publications: "Publications"
-      contact: "Contact"
+      home: "ホーム"
+      research: "プロジェクト"
+      teaching: "学習ノート"
+      talks: "イベント"
+      publications: "アウトプット"
+      contact: "コンタクト"


### PR DESCRIPTION
## Summary
- redesign the layout metadata and navigation copy for a math student persona
- rewrite every portfolio page to highlight projects, study notes, events, publications, and contact info suited to GitHub Pages
- refresh the global styles with a new color palette, hero section, and reusable components for cards, badges, and highlight lists

## Testing
- bundle exec rails test *(fails: bundler: command not found: rails)*
- bundle install *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68fc11185a548326b888f47265cf4be0